### PR TITLE
Custom RNG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "random-pairings"
 description = "Generates random pairings"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Herohtar <belac1186@gmail.com>"]
 repository = "https://github.com/Herohtar/random-pairings"
 keywords = ["random", "pairs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-js = ["getrandom/js"]
+# [features]
+# js = ["getrandom/js"]
 
 [dependencies]
-rand = "^0.8.5"
-getrandom = "^0.2.7"
+rand = { version = "^0.8.5", default-features = false }
+# getrandom = "^0.2.10"

--- a/src/pairing_generator.rs
+++ b/src/pairing_generator.rs
@@ -3,8 +3,7 @@ use crate::person::Person;
 use std::collections::VecDeque;
 
 use rand::{
-  thread_rng,
-  seq::SliceRandom,
+  seq::SliceRandom, Rng,
 };
 
 #[derive(Debug, Clone)]
@@ -43,11 +42,11 @@ impl PairingGenerator {
     Ok(())
   }
 
-  pub fn generate_pairings(&self) -> Vec<Person> {
+  pub fn generate_pairings<R>(&self, rng: &mut R) -> Vec<Person> where R: Rng + ?Sized {
     let mut unassigned_people = self.people.clone();
     let mut assigned_people: Vec<Person> = Vec::with_capacity(unassigned_people.len());
     let mut shuffled = unassigned_people.clone();
-    shuffled.shuffle(&mut thread_rng());
+    shuffled.shuffle(rng);
     let mut shuffled = VecDeque::from(shuffled);
 
     while unassigned_people.len() > 0 {


### PR DESCRIPTION
Allow package users to specify their own RNG instead of forcing a default on them. Removes unnecessary packages and features.